### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Include SPUserResizableView.h and SPUserResizableView.m in your project.
 You'll need to #import the SPUserResizableView.h header and construct a new instance of SPUserResizableView. Then, set the contentView on the SPUserResizableView to the view you'd like the user to interact with.
 
 ``` objective-c
-#import "SPUserResizableView.h"
+# import "SPUserResizableView.h"
 
 ...
     


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
